### PR TITLE
Add applet and themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,10 @@ A collection of COSMIC projects developed by the community.
 | [cosmic-applet-ollama](https://github.com/elevenhsoft/cosmic-applet-ollama) | Applet for Ollama | <img src="https://raw.githubusercontent.com/elevenhsoft/cosmic-ext-applet-ollama/main/screenshots/chat.png" alt="cosmic-applet-ollama" width="200"/> |
 | [cosmic-ext-applet-external-monitor-brightness](https://github.com/maciekk64/cosmic-ext-applet-external-monitor-brightness) | External Monitor Brightness Applet for the COSMIC™ desktop | <img src="https://raw.githubusercontent.com/maciekk64/cosmic-ext-applet-external-monitor-brightness/master/data/screenshot1.png" alt="cosmic-ext-applet-external-monitor-brightness" width="200"/> |
 
+## Themes
+| Name | Description | Image |
+|---|---|---|
+| [cosmic-desktop](https://github.com/catppuccin/cosmic-desktop) | Soothing pastel theme for COSMIC Desktop Environment | <img src="https://raw.githubusercontent.com/catppuccin/cosmic-desktop/main/assets/preview.webp" alt="cosmic-desktop" width="200"/> |
+
 ## How to add your project?
 To add your project to this list, please open a pull request with your project added to the `applications.ron` or `applets.ron` file.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ A collection of COSMIC projects developed by the community.
 | [cosmic-applet-places-status-indicator](https://github.com/leb-kuchen/cosmic-applet-places-status-indicator) | Menu for quickly navigating places in the system | <img src="https://preview.redd.it/here-there-are-cosmics-version-of-gnomes-popular-extension-v0-1vmlqqpeh9pc1.png?width=1920&format=png&auto=webp&s=fdfdffdb3e515a52651ab4e4c7496fc2ef686f7b" alt="cosmic-applet-places-status-indicator" width="200"/> |
 | [clipboard-manager](https://github.com/wiiznokes/clipboard-manager) | Clipboard manager for COSMIC™ | <img src="https://media.githubusercontent.com/media/wiiznokes/clipboard-manager/master/res/screenshots/main_popup.png" alt="clipboard-manager" width="200"/> |
 | [cosmic-applet-emoji-selector](https://github.com/leb-kuchen/cosmic-applet-emoji-selector) | Emoji selector | <img src="https://iili.io/JUazV7j.png" alt="cosmic-applet-emoji-selector" width="200"/> |
-| [cosmic-noise](https://github.com/bq-wrongway/cosmic-noise) | Applet for playing background noise | <img src="" alt="cosmic-noise" width="200"/> |
-| [cosmic-applet-ollama](https://github.com/elevenhsoft/cosmic-applet-ollama) | Applet for Ollama | <img src="https://github.com/elevenhsoft/cosmic-applet-ollama/blob/main/screenshots/chat.png" alt="cosmic-applet-ollama" width="200"/> |
+| [cosmic-noise](https://github.com/bq-wrongway/cosmic-noise) | Applet for playing background noise | |
+| [cosmic-applet-ollama](https://github.com/elevenhsoft/cosmic-applet-ollama) | Applet for Ollama | <img src="https://raw.githubusercontent.com/elevenhsoft/cosmic-ext-applet-ollama/main/screenshots/chat.png" alt="cosmic-applet-ollama" width="200"/> |
+| [cosmic-ext-applet-external-monitor-brightness](https://github.com/maciekk64/cosmic-ext-applet-external-monitor-brightness) | External Monitor Brightness Applet for the COSMIC™ desktop | <img src="https://raw.githubusercontent.com/maciekk64/cosmic-ext-applet-external-monitor-brightness/master/data/screenshot1.png" alt="cosmic-ext-applet-external-monitor-brightness" width="200"/> |
 
 ## How to add your project?
 To add your project to this list, please open a pull request with your project added to the `applications.ron` or `applets.ron` file.

--- a/applets.ron
+++ b/applets.ron
@@ -35,6 +35,12 @@ Applets(
       description: "Applet for Ollama",
       repo: "https://github.com/elevenhsoft/cosmic-applet-ollama",
       image: "https://github.com/elevenhsoft/cosmic-applet-ollama/blob/main/screenshots/chat.png"
+    ),
+    (
+      name: "cosmic-ext-applet-external-monitor-brightness",
+      description: "External Monitor Brightness Applet for the COSMIC™ desktop",
+      repo: "https://github.com/maciekk64/cosmic-ext-applet-external-monitor-brightness",
+      image: "https://github.com/maciekk64/cosmic-ext-applet-external-monitor-brightness/blob/master/data/screenshot1.png"
     )
   ]
 )

--- a/applets.ron
+++ b/applets.ron
@@ -1,3 +1,5 @@
+#![enable(implicit_some)]
+
 Applets(
   list: [
     (
@@ -28,19 +30,18 @@ Applets(
       name: "cosmic-noise",
       description: "Applet for playing background noise",
       repo: "https://github.com/bq-wrongway/cosmic-noise",
-      image: ""
     ),
     (
       name: "cosmic-applet-ollama",
       description: "Applet for Ollama",
       repo: "https://github.com/elevenhsoft/cosmic-applet-ollama",
-      image: "https://github.com/elevenhsoft/cosmic-applet-ollama/blob/main/screenshots/chat.png"
+      image: "https://raw.githubusercontent.com/elevenhsoft/cosmic-ext-applet-ollama/main/screenshots/chat.png"
     ),
     (
       name: "cosmic-ext-applet-external-monitor-brightness",
       description: "External Monitor Brightness Applet for the COSMIC™ desktop",
       repo: "https://github.com/maciekk64/cosmic-ext-applet-external-monitor-brightness",
-      image: "https://github.com/maciekk64/cosmic-ext-applet-external-monitor-brightness/blob/master/data/screenshot1.png"
+      image: "https://raw.githubusercontent.com/maciekk64/cosmic-ext-applet-external-monitor-brightness/master/data/screenshot1.png"
     )
   ]
 )

--- a/applications.ron
+++ b/applications.ron
@@ -1,3 +1,5 @@
+#![enable(implicit_some)]
+
 Applications(
   list: [
     (

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Applet {
     name: String,
     description: String,
     repo: String,
-    image: String,
+    image: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -18,7 +18,7 @@ struct Application {
     name: String,
     description: String,
     repo: String,
-    image: String,
+    image: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -30,8 +30,8 @@ fn main() -> anyhow::Result<()> {
     let applications_data = include_str!("../applications.ron");
     let applets_data = include_str!("../applets.ron");
     let mut readme = String::new();
-    let applications: Applications = ron::from_str(applications_data)?;
-    let applets: Applets = ron::from_str(applets_data)?;
+    let applications: Applications = ron::from_str(applications_data).unwrap();
+    let applets: Applets = ron::from_str(applets_data).unwrap();
 
     readme.push_str("# COSMIC Project Collection\n");
     readme.push_str("A collection of COSMIC projects developed by the community.\n\n");
@@ -42,7 +42,23 @@ fn main() -> anyhow::Result<()> {
     readme.push_str("|---|---|---|\n");
 
     for app in applications.list {
-        let row = format!("| [{}]({}) | {} | <img src=\"{}\" alt=\"{}\" width=\"200\"/> |\n", app.name, app.repo, app.description, app.image, app.name);
+        let mut row = String::new();
+
+        row.push_str(&format!(
+            "| [{}]({}) | {} |",
+            app.name, app.repo, app.description
+        ));
+
+        match app.image {
+            Some(image) => {
+                row.push_str(&format!(
+                    " <img src=\"{}\" alt=\"{}\" width=\"200\"/> |\n",
+                    image, app.name
+                ));
+            }
+            None => row.push_str(" |\n"),
+        }
+
         readme.push_str(&row);
     }
 
@@ -52,7 +68,23 @@ fn main() -> anyhow::Result<()> {
     readme.push_str("|---|---|---|\n");
 
     for applet in applets.list {
-        let row = format!("| [{}]({}) | {} | <img src=\"{}\" alt=\"{}\" width=\"200\"/> |\n", applet.name, applet.repo, applet.description, applet.image, applet.name);
+        let mut row = String::new();
+
+        row.push_str(&format!(
+            "| [{}]({}) | {} |",
+            applet.name, applet.repo, applet.description
+        ));
+
+        match applet.image {
+            Some(image) => {
+                row.push_str(&format!(
+                    " <img src=\"{}\" alt=\"{}\" width=\"200\"/> |\n",
+                    image, applet.name
+                ));
+            }
+            None => row.push_str(" |\n"),
+        }
+
         readme.push_str(&row);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,16 +26,45 @@ struct Applications {
     list: Vec<Application>,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct Theme {
+    name: String,
+    description: String,
+    repo: String,
+    image: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Themes {
+    list: Vec<Application>,
+}
+
 fn main() -> anyhow::Result<()> {
     let applications_data = include_str!("../applications.ron");
     let applets_data = include_str!("../applets.ron");
+    let themes_data = include_str!("../themes.ron");
     let mut readme = String::new();
     let applications: Applications = ron::from_str(applications_data).unwrap();
     let applets: Applets = ron::from_str(applets_data).unwrap();
+    let themes: Themes = ron::from_str(themes_data).unwrap();
 
     readme.push_str("# COSMIC Project Collection\n");
     readme.push_str("A collection of COSMIC projects developed by the community.\n\n");
 
+    write_applications(&mut readme, applications);
+    write_applets(&mut readme, applets);
+
+    write_themes(&mut readme, themes);
+
+    readme.push_str("\n## How to add your project?\n");
+    readme.push_str("To add your project to this list, please open a pull request with your project added to the `applications.ron` or `applets.ron` file.\n");
+
+    std::fs::write("README.md", readme)?;
+
+    Ok(())
+}
+
+fn write_applications(readme: &mut String, applications: Applications) {
     readme.push_str("## Applications\n");
 
     readme.push_str("| Name | Description | Image |\n");
@@ -61,7 +90,9 @@ fn main() -> anyhow::Result<()> {
 
         readme.push_str(&row);
     }
+}
 
+fn write_applets(readme: &mut String, applets: Applets) {
     readme.push_str("\n## Applets\n");
 
     readme.push_str("| Name | Description | Image |\n");
@@ -87,11 +118,32 @@ fn main() -> anyhow::Result<()> {
 
         readme.push_str(&row);
     }
+}
 
-    readme.push_str("\n## How to add your project?\n");
-    readme.push_str("To add your project to this list, please open a pull request with your project added to the `applications.ron` or `applets.ron` file.\n");
+fn write_themes(readme: &mut String, themes: Themes) {
+    readme.push_str("\n## Themes\n");
 
-    std::fs::write("README.md", readme)?;
+    readme.push_str("| Name | Description | Image |\n");
+    readme.push_str("|---|---|---|\n");
 
-    Ok(())
+    for applet in themes.list {
+        let mut row = String::new();
+
+        row.push_str(&format!(
+            "| [{}]({}) | {} |",
+            applet.name, applet.repo, applet.description
+        ));
+
+        match applet.image {
+            Some(image) => {
+                row.push_str(&format!(
+                    " <img src=\"{}\" alt=\"{}\" width=\"200\"/> |\n",
+                    image, applet.name
+                ));
+            }
+            None => row.push_str(" |\n"),
+        }
+
+        readme.push_str(&row);
+    }
 }

--- a/themes.ron
+++ b/themes.ron
@@ -3,7 +3,7 @@
 Themes(
   list: [
     (
-      name: "cosmic-desktop",
+      name: "catppuccin",
       description: "Soothing pastel theme for COSMIC Desktop Environment",
       repo: "https://github.com/catppuccin/cosmic-desktop",
       image: "https://raw.githubusercontent.com/catppuccin/cosmic-desktop/main/assets/preview.webp"

--- a/themes.ron
+++ b/themes.ron
@@ -1,0 +1,12 @@
+#![enable(implicit_some)]
+
+Themes(
+  list: [
+    (
+      name: "cosmic-desktop",
+      description: "Soothing pastel theme for COSMIC Desktop Environment",
+      repo: "https://github.com/catppuccin/cosmic-desktop",
+      image: "https://raw.githubusercontent.com/catppuccin/cosmic-desktop/main/assets/preview.webp"
+    )
+  ]
+)


### PR DESCRIPTION
- add https://github.com/maciekk64/cosmic-ext-applet-external-monitor-brightness
- add theme section for https://github.com/catppuccin/cosmic-desktop
- allow optional image (fix no image found symbol for cosmic-noise)
- use raw image instead of github website link for some applets

close #16 